### PR TITLE
Added build workflows

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -1,0 +1,74 @@
+name: Build Android
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - precision: single
+            arch: arm64
+            abi: arm64-v8a
+            artifact: Android-ARM
+          - precision: single
+            arch: x86_64
+            abi: x86_64
+            artifact: Android-x64
+          - precision: single
+            arch: x86_32
+            abi: x86
+            artifact: Android-x86
+
+          - precision: double
+            arch: arm64
+            abi: arm64-v8a
+            artifact: Android-ARM-double
+          - precision: double
+            arch: x86_64
+            abi: x86_64
+            artifact: Android-x64-double
+          - precision: double
+            arch: x86_32
+            abi: x86
+            artifact: Android-x86-double
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download Opus Models
+        working-directory: ./thirdparty/opus
+        run: ./autogen.sh
+
+      - name: Create Opus build dir
+        working-directory: ./thirdparty/opus
+        run: mkdir build
+
+      - name: Configure Opus
+        working-directory: ./thirdparty/opus/build
+        run: cmake .. -DCMAKE_TOOLCHAIN_FILE=${ANDROID_HOME}/ndk/25.2.9519653/build/cmake/android.toolchain.cmake -DANDROID_ABI=${{ matrix.abi }} -DCMAKE_BUILD_TYPE=Release -DOPUS_BUILD_PROGRAMS=ON -DBUILD_TESTING=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+
+      - name: Build Opus
+        working-directory: ./thirdparty/opus/build
+        run: cmake --build . -j 2 --config Release
+
+      - name: 🔗 GDExtension Build
+        uses: godotengine/godot-cpp-template/.github/actions/build@main
+        with:
+          platform: android
+          arch: ${{ matrix.arch }}
+          float-precision: ${{ matrix.precision }}
+          build-target-type: template_release
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Godot_Opus-${{ matrix.artifact }}
+          path: |
+            ${{ github.workspace }}/bin/**/*.so
+          if-no-files-found: error

--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -1,0 +1,60 @@
+name: Build iOS
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - precision: single
+            arch: arm64
+            ios_precision_extension:
+            artifact: iOS
+          - precision: double
+            arch: arm64
+            ios_precision_extension: .double
+            artifact: iOS-double
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install AutoConf, AutoMake and LibTool # Needed for autogen.sh
+        run: brew install autoconf automake libtool
+
+      - name: Download Opus Models
+        working-directory: ./thirdparty/opus
+        run: ./autogen.sh
+
+      - name: Create Opus build dir
+        working-directory: ./thirdparty/opus
+        run: mkdir build
+
+      - name: Configure Opus
+        working-directory: ./thirdparty/opus/build
+        run: cmake .. -G "Unix Makefiles" -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_BUILD_TYPE=Release -DOPUS_BUILD_PROGRAMS=ON -DBUILD_TESTING=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+
+      - name: Build Opus
+        working-directory: ./thirdparty/opus/build
+        run: cmake --build . -j 2 --config Release
+
+      - name: 🔗 GDExtension Build
+        uses: godotengine/godot-cpp-template/.github/actions/build@main
+        with:
+          platform: ios
+          arch: ${{ matrix.arch }}
+          float-precision: ${{ matrix.precision }}
+          build-target-type: template_release
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Godot_Opus-${{ matrix.artifact }}
+          path: |
+            ${{ github.workspace }}/bin/**/libgodot_opus.ios.template_release${{ matrix.ios_precision_extension }}.arm64.framework/**
+          if-no-files-found: error

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -1,0 +1,61 @@
+name: Build Linux
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - precision: single
+            arch: x86_64
+            artifact: Linux
+          - precision: double
+            arch: x86_64
+            artifact: Linux-double
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download Opus Models
+        working-directory: ./thirdparty/opus
+        run: ./autogen.sh
+
+      - name: Create Opus build dir
+        working-directory: ./thirdparty/opus
+        run: mkdir build
+
+      - name: Configure Opus
+        working-directory: ./thirdparty/opus/build
+        run: cmake .. -DCMAKE_BUILD_TYPE=Release -DOPUS_BUILD_PROGRAMS=ON -DBUILD_TESTING=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DOPUS_STATIC_RUNTIME=ON
+
+      - name: Build Opus
+        working-directory: ./thirdparty/opus/build
+        run: cmake --build . -j 2 --config Release
+
+      - name: Test Opus
+        working-directory: ./thirdparty/opus/build
+        run: ctest -j 2 -C Release --output-on-failure
+
+      - name: 🔗 GDExtension Build
+        uses: godotengine/godot-cpp-template/.github/actions/build@main
+        with:
+          platform: linux
+          arch: ${{ matrix.arch }}
+          float-precision: ${{ matrix.precision }}
+          build-target-type: template_release
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Godot_Opus-${{ matrix.artifact }}
+          path: |
+            ${{ github.workspace }}/bin/**/*.so
+          if-no-files-found: error

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -1,0 +1,89 @@
+name: Build MacOS
+on:
+  workflow_dispatch:
+  workflow_call:
+    # secrets:
+    #   APPLE_CERT_BASE64:
+    #     required: true
+    #   APPLE_CERT_PASSWORD:
+    #     required: true
+    #   APPLE_DEV_PASSWORD:
+    #     required: true
+    #   APPLE_DEV_ID:
+    #     required: true
+    #   APPLE_DEV_TEAM_ID:
+    #     required: true
+    #   APPLE_DEV_APP_ID:
+    #     required: true
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - precision: single
+            mac_precision_extension:
+            arch: universal
+            artifact: MacOSX
+          - precision: double
+            mac_precision_extension: .double
+            arch: universal
+            artifact: MacOSX-double
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install AutoConf, AutoMake and LibTool # Needed for autogen.sh
+        run: brew install autoconf automake libtool
+
+      - name: Download Opus Models
+        working-directory: ./thirdparty/opus
+        run: ./autogen.sh
+
+      - name: Create Opus build dir
+        working-directory: ./thirdparty/opus
+        run: mkdir build
+
+      - name: Configure Opus
+        working-directory: ./thirdparty/opus/build
+        run: cmake .. -DCMAKE_BUILD_TYPE=Release -DOPUS_BUILD_PROGRAMS=ON -DBUILD_TESTING=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+
+      - name: Build Opus
+        working-directory: ./thirdparty/opus/build
+        run: cmake --build . -j 2 --config Release
+
+      - name: Test Opus
+        working-directory: ./thirdparty/opus/build
+        run: ctest -j 2 -C Release --output-on-failure
+
+      - name: 🔗 GDExtension Build
+        uses: godotengine/godot-cpp-template/.github/actions/build@main
+        with:
+          platform: macos
+          arch: ${{ matrix.arch }}
+          float-precision: ${{ matrix.precision }}
+          build-target-type: template_release
+
+    #   - name: Mac Sign
+    #     uses: godotengine/godot-cpp-template/.github/actions/sign@main
+    #     with:
+    #       FRAMEWORK_PATH: bin/addons/godot_opus/bin/libgodot_opus.macos.template_release${{ matrix.mac_precision_extension }}.universal.framework
+    #       SIGN_FLAGS: "--deep"
+    #       APPLE_CERT_BASE64: ${{ secrets.APPLE_CERT_BASE64 }}
+    #       APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+    #       APPLE_DEV_PASSWORD: ${{ secrets.APPLE_DEV_PASSWORD }}
+    #       APPLE_DEV_ID: ${{ secrets.APPLE_DEV_ID }}
+    #       APPLE_DEV_TEAM_ID: ${{ secrets.APPLE_DEV_TEAM_ID }}
+    #       APPLE_DEV_APP_ID: ${{ secrets.APPLE_DEV_APP_ID }}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Godot_Opus-${{ matrix.artifact }}
+          path: |
+            ${{ github.workspace }}/bin/**/libgodot_opus.macos.template_release${{ matrix.mac_precision_extension }}.universal.framework/**
+          if-no-files-found: error

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,0 +1,69 @@
+name: Build Windows
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - precision: single
+            arch: x86_32
+            opus_arch: Win32
+            artifact: Win32
+          - precision: single
+            arch: x86_64
+            opus_arch: x64
+            artifact: Win64
+          - precision: double
+            arch: x86_32
+            opus_arch: Win32
+            artifact: Win32-double
+          - precision: double
+            arch: x86_64
+            opus_arch: x64
+            artifact: Win64-double
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download Opus Models
+        working-directory: ./thirdparty/opus
+        run: .\autogen.bat
+
+      - name: Create Opus build dir
+        working-directory: ./thirdparty/opus
+        run: mkdir build
+
+      - name: Configure Opus
+        working-directory: ./thirdparty/opus/build
+        run: cmake .. -G "Visual Studio 17 2022" -A ${{ matrix.opus_arch }} -DCMAKE_BUILD_TYPE=Release -DOPUS_BUILD_PROGRAMS=ON -DBUILD_TESTING=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DOPUS_STATIC_RUNTIME=ON
+
+      - name: Build Opus
+        working-directory: ./thirdparty/opus/build
+        run: cmake --build . -j 2 --config Release
+
+      - name: Test Opus
+        working-directory: ./thirdparty/opus/build
+        run: ctest -j 2 -C Release --output-on-failure
+
+      - name: 🔗 GDExtension Build
+        uses: godotengine/godot-cpp-template/.github/actions/build@main
+        with:
+          platform: windows
+          arch: ${{ matrix.arch }}
+          float-precision: ${{ matrix.precision }}
+          build-target-type: template_release
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Godot_Opus-${{ matrix.artifact }}
+          path: |
+            ${{ github.workspace }}/bin/**/*.dll
+          if-no-files-found: error

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup clang-format
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,20 +4,28 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - name: Checkout 
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
-          submodules: true
           fetch-depth: 0
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
         with:
-          name: Godot_Opus
+          name: Godot_Opus-Common
+          path: |
+            ${{ github.workspace }}/bin/samples/**
+            ${{ github.workspace }}/bin/addons/godot_opus/godot_opus.gdextension
+            ${{ github.workspace }}/bin/addons/godot_opus/godot_opus.svg
+          if-no-files-found: error
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
           path: godot-opus
+          merge-multiple: true
       - name: Delete draft release(s)
         uses: hugo19941994/delete-draft-releases@v1.0.0
         env:

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -10,18 +10,18 @@ on:
 jobs:
   lint:
     uses: ./.github/workflows/lint.yml
-#   build_android:
-#     needs: [lint]
-#     uses: ./.github/workflows/build_android.yml
-#   build_ios:
-#     needs: [lint]
-#     uses: ./.github/workflows/build_ios.yml
-#   build_linux:
-#     needs: [lint]
-#     uses: ./.github/workflows/build_linux.yml
-#   build_macos:
-#     needs: [lint]
-#     uses: ./.github/workflows/build_macos.yml
+  build_android:
+    needs: [lint]
+    uses: ./.github/workflows/build_android.yml
+  build_ios:
+    needs: [lint]
+    uses: ./.github/workflows/build_ios.yml
+  build_linux:
+    needs: [lint]
+    uses: ./.github/workflows/build_linux.yml
+  build_macos:
+    needs: [lint]
+    uses: ./.github/workflows/build_macos.yml
 #     secrets:
 #       APPLE_CERT_BASE64: ${{ secrets.APPLE_CERT_BASE64 }}
 #       APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
@@ -29,17 +29,13 @@ jobs:
 #       APPLE_DEV_ID: ${{ secrets.APPLE_DEV_ID }}
 #       APPLE_DEV_TEAM_ID: ${{ secrets.APPLE_DEV_TEAM_ID }}
 #       APPLE_DEV_APP_ID: ${{ secrets.APPLE_DEV_APP_ID }}
-#   build_windows:
-#     needs: [lint]
-#     uses: ./.github/workflows/build_windows.yml
-#   build_web:
-#     needs: [lint]
-#     uses: ./.github/workflows/build_web.yml
+  build_windows:
+    needs: [lint]
+    uses: ./.github/workflows/build_windows.yml
 
-#   release:
-#     name: Create Release
-#     permissions:
-#       contents: write
-#     # needs: [build_android, build_ios, build_linux, build_macos, build_windows, build_web]
-#     needs: [lint]
-#     uses: ./.github/workflows/release.yml
+  release:
+    name: Create Release
+    permissions:
+      contents: write
+    needs: [build_android, build_ios, build_linux, build_macos, build_windows]
+    uses: ./.github/workflows/release.yml

--- a/SConstruct
+++ b/SConstruct
@@ -14,25 +14,25 @@ env = SConscript("thirdparty/godot-cpp/SConstruct")
 
 # tweak this if you want to use different folders, or more folders, to store your source code in.
 env.Append(CPPPATH=["src/", "thirdparty/opus/include/"])
-env.Append(LIBPATH=["thirdparty/opus/build"])
 sources = Glob("src/*.cpp")
 
-if env["platform"] == "linux":
-    env.Append(LIBS="libopus")
-elif env["platform"] == "windows":
+if env["platform"] == "windows":
+    env.Append(LIBPATH=["thirdparty/opus/build/Release"])
     env.Append(LIBS="opus.lib")
+else:
+    env.Append(LIBPATH=["thirdparty/opus/build"])
+    env.Append(LIBS="libopus")
 
-
-if env["platform"] == "macos":
+if env["platform"] == "macos" or env["platform"] == "ios":
     library = env.SharedLibrary(
-        "bin/addons/godot_opus/{}/libgodot_opus.{}.{}.framework/libgodot_opus.{}.{}".format(
-            env["platform"], env["platform"], env["target"], env["platform"], env["target"]
+        "bin/addons/godot_opus/bin/libgodot_opus{}.framework/libgodot_opus{}".format(
+            env["suffix"], env["suffix"]
         ),
         source=sources,
     )
 else:
     library = env.SharedLibrary(
-        "bin/addons/godot_opus/{}/libgodot_opus{}{}".format(env["platform"], env["suffix"], env["SHLIBSUFFIX"]),
+        "bin/addons/godot_opus/bin/libgodot_opus{}{}".format(env["suffix"], env["SHLIBSUFFIX"]),
         source=sources,
     )
 

--- a/bin/addons/godot_opus/godot_opus.gdextension
+++ b/bin/addons/godot_opus/godot_opus.gdextension
@@ -1,13 +1,48 @@
 [configuration]
+
 entry_symbol = "godot_opus_library_init"
 compatibility_minimum = "4.1"
 
 [icons]
+
 GodotOpus = "godot_opus.svg"
 
 [libraries]
-windows.debug.x86_64 = "windows/libgodot_opus.windows.template_debug.x86_64.dll"
-windows.release.x86_64 = "windows/libgodot_opus.windows.template_release.x86_64.dll"
-linux.debug.x86_64 = "linux/libgodot_opus.linux.template_debug.x86_64.so"
-linux.release.x86_64 = "linux/libgodot_opus.linux.template_release.x86_64.so"
 
+macos.debug = "bin/libgodot_opus.macos.template_release.universal.framework"
+macos.release = "bin/libgodot_opus.macos.template_release.universal.framework"
+macos.debug.double = "bin/libgodot_opus.macos.template_release.double.universal.framework"
+macos.release.double = "bin/libgodot_opus.macos.template_release.double.universal.framework"
+
+ios.debug = "bin/libgodot_opus.ios.template_release.arm64.dylib"
+ios.release = "bin/libgodot_opus.ios.template_release.arm64.dylib"
+ios.debug.double = "bin/libgodot_opus.ios.template_release.double.arm64.dylib"
+ios.release.double = "bin/libgodot_opus.ios.template_release.double.arm64.dylib"
+
+windows.debug.x86_32 = "bin/libgodot_opus.windows.template_release.x86_32.dll"
+windows.release.x86_32 = "bin/libgodot_opus.windows.template_release.x86_32.dll"
+windows.debug.x86_64 = "bin/libgodot_opus.windows.template_release.x86_64.dll"
+windows.release.x86_64 = "bin/libgodot_opus.windows.template_release.x86_64.dll"
+windows.debug.double.x86_32 = "bin/libgodot_opus.windows.template_release.double.x86_32.dll"
+windows.release.double.x86_32 = "bin/libgodot_opus.windows.template_release.double.x86_32.dll"
+windows.debug.double.x86_64 = "bin/libgodot_opus.windows.template_release.double.x86_64.dll"
+windows.release.double.x86_64 = "bin/libgodot_opus.windows.template_release.double.x86_64.dll"
+
+linux.debug.x86_64 = "bin/libgodot_opus.linux.template_release.x86_64.so"
+linux.release.x86_64 = "bin/libgodot_opus.linux.template_release.x86_64.so"
+linux.debug.double.x86_64 = "bin/libgodot_opus.linux.template_release.double.x86_64.so"
+linux.release.double.x86_64 = "bin/libgodot_opus.linux.template_release.double.x86_64.so"
+
+android.debug.x86_64 = "bin/libgodot_opus.android.template_release.x86_64.so"
+android.release.x86_64 = "bin/libgodot_opus.android.template_release.x86_64.so"
+android.debug.x86_32 = "bin/libgodot_opus.android.template_release.x86_32.so"
+android.release.x86_32 = "bin/libgodot_opus.android.template_release.x86_32.so"
+android.debug.arm64 = "bin/libgodot_opus.android.template_release.arm64.so"
+android.release.arm64 = "bin/libgodot_opus.android.template_release.arm64.so"
+
+android.debug.double.x86_64 = "bin/libgodot_opus.android.template_release.double.x86_64.so"
+android.release.double.x86_64 = "bin/libgodot_opus.android.template_release.double.x86_64.so"
+android.debug.double.x86_32 = "bin/libgodot_opus.android.template_release.double.x86_32.so"
+android.release.double.x86_32 = "bin/libgodot_opus.android.template_release.double.x86_32.so"
+android.debug.double.arm64 = "bin/libgodot_opus.android.template_release.double.arm64.so"
+android.release.double.arm64 = "bin/libgodot_opus.android.template_release.double.arm64.so"


### PR DESCRIPTION
Implement all supported build workflows for Godot Opus.

The Opus build steps were adapted from the Opus repo, while the Godot GDExtension related steps came from Godot-Whisper. I changed the `checkout`, `upload-artifact`, and `download-artifact` actions to v4.

All major platforms are supported, except web. I'm not sure if I can get Opus building for that, as it's not targeted by the codec itself. I'll leave it for now. Also, the MacOS builds are _not_ signed.