### PR TITLE
Add support for Variable Bitrate, and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@
 **/*.os
 .vscode/
 .sconsign.dblite
-bin/addons/godot_opus/linux/
-bin/addons/godot_opus/windows/
+build/
+bin/addons/godot_opus/bin/
 godot_opus.zip

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Godot Opus
-A GDExtension addon for the Godot engine for VOIP and other real-time audio compression using the Opus audio codec (https://opus-codec.org/).
+A GDExtension addon for the Godot engine for VOIP and other real-time audio compression using the [Opus audio codec](https://opus-codec.org).
 
-- Bitrates from 6 kb/s to 510 kb/s
+- Bitrates from 6 kb/s to 512 kb/s
 - Sampling rates from 8 kHz (narrowband) to 48 kHz (fullband)
 - Frame sizes from 2.5 ms to 120 ms
-- Support for constant bitrate (variable bitrate not implemented)
+- Support for variable bitrate and constant bitrate
 - Audio bandwidth from narrowband to fullband
 - Support for speech and music
 - Support for mono and stereo
 - Good loss robustness and packet loss concealment (PLC)
 - Floating point implementation (fixed-point not implemented)
 
-**Note:** Does not implement variable bitrate. Does not support Opus DRED decoder. Does not use Opus Repacketizer or Multistream API.
+**Note:** Does not support Opus DRED decoder. Does not use Opus Repacketizer or Multistream API.
 
 See the demo project in `samples/godot_opus` for more info on how to use.

--- a/bin/addons/godot_opus/doc_classes/godot_opus.xml
+++ b/bin/addons/godot_opus/doc_classes/godot_opus.xml
@@ -140,6 +140,21 @@
 		<member name="bandwidth" type="int" setter="set_bandwidth" getter="get_bandwidth" enum="GodotOpus.Bandwidth" default="-1000">
 			Bandwidth parameter used by the Opus codec. Default is Auto Bandwidth.
 		</member>
+		<member name="max_bandwidth" type="int" setter="set_max_bandwidth" getter="get_max_bandwidth" enum="GodotOpus.Bandwidth" default="1105">
+			Max bandwidth parameter used by the Opus codec. Default is Fullband.
+		</member>
+		<member name="bitrate_mode" type="int" setter="set_bitrate_mode" getter="get_bitrate_mode" enum="GodotOpus.BitrateMode" default="-1000">
+			Bitrate Mode of the Opus codec, used to configure Variable bitrate (VBR), or Constant bitrate (CBR). VBR has submodes for Auto, Max Bitrate, and Manual bitrate.
+		</member>
+		<member name="bitrate" type="int" setter="set_bitrate" getter="get_bitrate" default="120000">
+			Bitrate to use (in bits per second, bps) when in VBR Manual or CBR bitrate modes.
+		</member>
+		<member name="encoder_complexity" type="int" setter="set_encoder_complexity" getter="get_encoder_complexity" default="10">
+			Configures the encoder's computational complexity. Complexity is a value from 0 to 10, where 0 is the lowest complexity and 10 is the highest.
+		</member>
+		<member name="packet_loss" type="int" setter="set_packet_loss_perc" getter="get_packet_loss_perc" default="0">
+			Packet loss percentage, in the range 0-100. Higher values trigger progressively more loss resistant behavior in the encoder at the expense of quality at a given bitrate in the absence of packet loss, but greater quality under loss.
+		</member>
 		<member name="max_payload_bytes" type="int" setter="set_max_payload_bytes" getter="get_max_payload_bytes" default="1024">
 			Max allowed size of the packet payload of an encoded frame, in bytes. Should not be used to limit bandwidth, just as an upper bound on the size of encoded packets.
 		</member>
@@ -222,6 +237,18 @@
 		</constant>
 		<constant name="BANDWIDTH_AUTO" value="-1000" enum="Bandwidth">
 			Lets the encoder choose the optimal bandpass.
+		</constant>
+		<constant name="BITRATE_VARIABLE_AUTO" value="-1000" enum="BitrateMode">
+			Enables VBR mode, lets the encoder choose the optimal bitrate.
+		</constant>
+		<constant name="BITRATE_VARIABLE_BITRATE_MAX" value="-1" enum="BitrateMode">
+			Enables VBR mode, encoder uses maximum available bitrate.
+		</constant>
+		<constant name="BITRATE_VARIABLE_MANUAL" value="0" enum="BitrateMode">
+			Enables VBR mode, encoder uses the configured bitrate.
+		</constant>
+		<constant name="BITRATE_CONSTANT" value="1" enum="BitrateMode">
+			Disables VBR, uses CBR mode. Encoder uses the configured bitrate.
 		</constant>
 	</constants>
 </class>

--- a/bin/samples/godot_opus/demo.tscn
+++ b/bin/samples/godot_opus/demo.tscn
@@ -31,10 +31,8 @@ one_shot = true
 [node name="UI" type="Control" parent="."]
 layout_mode = 3
 anchors_preset = 0
-offset_left = 278.0
-offset_top = 144.0
-offset_right = 874.0
-offset_bottom = 504.0
+offset_right = 1152.0
+offset_bottom = 648.0
 
 [node name="PanelContainer" type="PanelContainer" parent="UI"]
 layout_mode = 1
@@ -44,9 +42,9 @@ anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
 offset_left = -320.0
-offset_top = -201.5
+offset_top = -260.0
 offset_right = 320.0
-offset_bottom = 218.5
+offset_bottom = 260.0
 grow_horizontal = 2
 grow_vertical = 2
 
@@ -169,6 +167,40 @@ popup/item_7/id = 7
 popup/item_8/text = "120 ms"
 popup/item_8/id = 8
 
+[node name="BitRateModeLabel" type="Label" parent="UI/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/GridContainer"]
+layout_mode = 2
+tooltip_text = "Bit Rate of the transmitted packets."
+mouse_filter = 0
+text = "Bit Rate Mode"
+
+[node name="BitRateModeOptions" type="OptionButton" parent="UI/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/GridContainer"]
+layout_mode = 2
+item_count = 4
+selected = 0
+popup/item_0/text = "VBR Auto"
+popup/item_0/id = 0
+popup/item_1/text = "VBR Max Bitrate"
+popup/item_1/id = 1
+popup/item_2/text = "VBR Manual"
+popup/item_2/id = 2
+popup/item_3/text = "CBR"
+popup/item_3/id = 3
+
+[node name="TargetBitRateLabel" type="Label" parent="UI/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/GridContainer"]
+layout_mode = 2
+tooltip_text = "Bit Rate of the transmitted packets."
+mouse_filter = 0
+text = "Target Bit Rate"
+
+[node name="TargetBitRateSpinBox" type="SpinBox" parent="UI/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/GridContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = 6.0
+max_value = 512.0
+value = 12.0
+exp_edit = true
+suffix = "kbps"
+
 [node name="BandwidthLabel" type="Label" parent="UI/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/GridContainer"]
 layout_mode = 2
 tooltip_text = "Bandwidth target of the Opus 
@@ -211,5 +243,7 @@ suffix = "%"
 [connection signal="item_selected" from="UI/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/GridContainer/OpusEnabledOptions" to="." method="_on_opus_enabled_options_item_selected"]
 [connection signal="item_selected" from="UI/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/GridContainer/ChannelsOptions" to="." method="_on_channels_options_item_selected"]
 [connection signal="item_selected" from="UI/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/GridContainer/FrameDurationOptions" to="." method="_on_frame_duration_options_item_selected"]
+[connection signal="item_selected" from="UI/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/GridContainer/BitRateModeOptions" to="." method="_on_bit_rate_mode_options_item_selected"]
+[connection signal="value_changed" from="UI/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/GridContainer/TargetBitRateSpinBox" to="." method="_on_target_bit_rate_spin_box_value_changed"]
 [connection signal="item_selected" from="UI/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/GridContainer/BandwidthOptions" to="." method="_on_bandwidth_options_item_selected"]
 [connection signal="value_changed" from="UI/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/GridContainer/DropRateSpinBox" to="." method="_on_drop_rate_spin_box_value_changed"]

--- a/src/godot_opus.h
+++ b/src/godot_opus.h
@@ -52,6 +52,13 @@ public:
 		BANDWIDTH_AUTO = OPUS_AUTO
 	};
 
+	enum BitrateMode {
+		BITRATE_VARIABLE_AUTO = OPUS_AUTO,
+		BITRATE_VARIABLE_BITRATE_MAX = OPUS_BITRATE_MAX,
+		BITRATE_VARIABLE_MANUAL = 0,
+		BITRATE_CONSTANT = 1
+	};
+
 private:
 	OpusEncoder *encoder;
 	OpusDecoder *decoder;
@@ -76,10 +83,16 @@ private:
 	ApplicationMode application_mode;
 	FrameSizeDuration frame_duration;
 	Bandwidth bandwidth;
+	Bandwidth max_bandwidth;
 
 	int max_payload_bytes;
 	int max_frame_size;
 	int frame_size;
+
+	BitrateMode bitrate_mode;
+	int bitrate_bps;
+	int encoder_complexity;
+	int packet_loss_perc;
 
 	float buffer_length_seconds;
 
@@ -150,6 +163,23 @@ public:
 	void set_bandwidth(const GodotOpus::Bandwidth p_bandwidth);
 	GodotOpus::Bandwidth get_bandwidth() const;
 
+	void set_max_bandwidth(const GodotOpus::Bandwidth p_bandwidth);
+	GodotOpus::Bandwidth get_max_bandwidth() const;
+
+	void set_encoder_complexity(const int p_complexity);
+	int get_encoder_complexity() const;
+
+	// Dynamic properties
+
+	void set_bitrate_mode(const GodotOpus::BitrateMode p_mode);
+	GodotOpus::BitrateMode get_bitrate_mode() const;
+
+	void set_bitrate(const int p_bitrate);
+	int get_bitrate() const;
+
+	void set_packet_loss_perc(const int p_packet_loss_perc);
+	int get_packet_loss_perc() const;
+
 	// Not exposed as a property
 	int get_frame_size() const;
 
@@ -164,5 +194,6 @@ VARIANT_ENUM_CAST(GodotOpus::Channels);
 VARIANT_ENUM_CAST(GodotOpus::ApplicationMode);
 VARIANT_ENUM_CAST(GodotOpus::FrameSizeDuration);
 VARIANT_ENUM_CAST(GodotOpus::Bandwidth);
+VARIANT_ENUM_CAST(GodotOpus::BitrateMode);
 
 #endif // GODOT_OPUS_H


### PR DESCRIPTION
Godot Opus now lets a user change between VBR and CBR. To handle the special VBR values (auto, max), the VBR/CBR mode has been combined with them into `bitrate_mode`. Depending on the mode, this also adds `bitrate`, for VBR manual and CBR modes. Setting these can be done without re-initializing the codec.

Added support for some other Opus parameters:

`packet_loss_perc` - Packet loss percentage, which helps quality when packets are being dropped.

`encoder_complexity` - Configure how much computational complexity the encoder will use when encoding. Presumably higher complexity takes more compute, but results in better (smaller? clearer?) packets.

`max_bandwidth` - Another parameter that can be tweaked when trying to optimize encoding. See Opus docs for details.